### PR TITLE
Fixed missing glibc problem in alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM alpine:3.4
 
+# Hack alpine into thinking that muslc lib is Glibc lib.
+# Since they are compatible, the program will not notice any difference.
+# Source: http://stackoverflow.com/a/35613430/3461549
+RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+
 COPY synpost_stats /usr/local/bin/
 
 CMD ["synpost_stats"]


### PR DESCRIPTION
Hacked alpine into thinking that muslc lib is glibc lib.
Since they are both compatible, the program will run without any
problems.

Source: http://stackoverflow.com/a/35613430/3461549